### PR TITLE
replace fastp by RabbitQC

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -30,7 +30,7 @@ SOFTWARE.
 #ifndef COMMON_H
 #define COMMON_H
 
-#define FASTP_VER "0.0.1"
+#define RABBITQC_VER "0.0.1"
 
 #define _DEBUG false
 

--- a/src/htmlreporter.cpp
+++ b/src/htmlreporter.cpp
@@ -111,7 +111,7 @@ void HtmlReporter::printSummary(ofstream& ofs, FilterResult* result, Stats* preS
     ofs << "<div class='subsection_title' onclick=showOrHide('general')>General</div>\n";
     ofs << "<div id='general'>\n";
     ofs << "<table class='summary_table'>\n";
-    outputRow(ofs, "fastp version:", string(FASTP_VER)+ " (<a href='https://github.com/ZekunYin/RabbitQC'>https://github.com/ZekunYin/RabbitQC</a>)");
+    outputRow(ofs, "RabbitQC version:", string(RABBITQC_VER)+ " (<a href='https://github.com/ZekunYin/RabbitQC'>https://github.com/ZekunYin/RabbitQC</a>)");
     outputRow(ofs, "sequencing:", sequencingInfo);
 
     // report read length change
@@ -409,7 +409,7 @@ void HtmlReporter::report3(TGSStats* preStats1, TGSStats* postStats1, TGSStats* 
 
 void HtmlReporter::printHeader(ofstream& ofs){
     ofs << "<html><head><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\" />";
-    //ofs << "<title>fastp report at " + getCurrentSystemTime() + " </title>";
+    //ofs << "<title>RabbitQC report at " + getCurrentSystemTime() + " </title>";
     ofs << "<title>RabbitQC report at " + getCurrentSystemTime() + " </title>";
     printJS(ofs);
     printCSS(ofs);
@@ -472,6 +472,6 @@ void HtmlReporter::printFooter(ofstream& ofs){
     ofs << "\n</div>" << endl;
     ofs << "<div id='footer'> ";
     ofs << "<p>"<<command<<"</p>";
-    ofs << "fastp " << FASTP_VER << ", at " << getCurrentSystemTime() << " </div>";
+    ofs << "RabbitQC " << RABBITQC_VER << ", at " << getCurrentSystemTime() << " </div>";
     ofs << "</body></html>";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ mutex logmtx;
 int main(int argc, char* argv[]){
     // display version info if no argument is given
     if(argc == 1) {
-        cerr << "rabbit_qc: an ultra-fast all-in-one FASTQ preprocessor" << endl << "version " << FASTP_VER << endl;
+        cerr << "rabbit_qc: an ultra-fast all-in-one FASTQ preprocessor" << endl << "version " << RABBITQC_VER << endl;
         //cerr << "fastp --help to see the help"<<endl;
         //return 0;
     }
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]){
         return 0;
     }
     if (argc == 2 && (strcmp(argv[1], "-v")==0 || strcmp(argv[1], "--version")==0)){
-        cerr << "rabbit_qc " << FASTP_VER << endl;
+        cerr << "rabbit_qc " << RABBITQC_VER << endl;
         return 0;
     }
 	//detect cpu cores using openmp
@@ -401,7 +401,7 @@ int main(int argc, char* argv[]){
     cerr << endl << "JSON report: " << opt.jsonFile << endl;
     cerr << "HTML report: " << opt.htmlFile << endl;
     cerr << endl << command << endl;
-    cerr << "rabbit_qc v" << FASTP_VER << ", time used: " << (t2)-t1 << " seconds" << endl;
+    cerr << "rabbit_qc v" << RABBITQC_VER << ", time used: " << (t2)-t1 << " seconds" << endl;
 
     return 0;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -129,7 +129,7 @@ bool Options::validate() {
     if(thread < 1) {
         thread = 1;
     } else if(thread > 64) {
-        cerr << "WARNING: fastp uses up to 16 threads although you specified " << thread << endl;
+        cerr << "WARNING: RabbitQC uses up to 16 threads although you specified " << thread << endl;
         thread = 64;
     }
 


### PR DESCRIPTION
in various locations, e.g. within the HTML report, RabbitQC reports itself as fastp. This PR replaces
these occurences with the RabbitQC string.